### PR TITLE
reduce shooter velocity samples from 64 to 8

### DIFF
--- a/robotbase/src/main/java/frc/robot/Constants.java
+++ b/robotbase/src/main/java/frc/robot/Constants.java
@@ -15,6 +15,7 @@ import static edu.wpi.first.units.Units.RotationsPerSecondPerSecond;
 import static edu.wpi.first.units.Units.Seconds;
 
 import choreo.auto.AutoFactory;
+import com.revrobotics.spark.config.EncoderConfig;
 import com.revrobotics.spark.config.SignalsConfig;
 import com.revrobotics.spark.config.SparkBaseConfig;
 import com.revrobotics.spark.config.SparkBaseConfig.IdleMode;
@@ -520,6 +521,9 @@ public class Constants {
         .idleMode(IdleMode.kCoast)
         .smartCurrentLimit((int) STALL_LIMIT.in(Amps), 40)
         .voltageCompensation(12);
+
+    public static final EncoderConfig ENCODER_CONFIG =
+      SHOOTER_BASE_CONFIG.encoder.quadratureAverageDepth(8);
 
     public static final SparkBaseConfig RIGHT_MOTOR_CONFIG =
       new SparkMaxConfig()


### PR DESCRIPTION
<img width="1582" height="790" alt="Screenshot 2026-04-16 182932" src="https://github.com/user-attachments/assets/2ca16153-0c26-418f-a357-29f62dd5efed" />

Green/Yellow is the default sample size of 64, and Blue/Purple is the reduced sample size of 8.

The resulting velocity follows the setpoint much more closely without such significant peaks and valleys.